### PR TITLE
Add support for .NET Standard 2.0

### DIFF
--- a/Extensions/CngKeyExtensions.cs
+++ b/Extensions/CngKeyExtensions.cs
@@ -46,10 +46,10 @@ namespace SecurityDriven.Inferno.Extensions
 		/// </summary>
 		public static byte[] GetSharedDhmSecret(this CngKey privateDhmKey, CngKey publicDhmKey, byte[] contextAppend = null, byte[] contextPrepend = null)
 		{
-#if NET462
+#if NETFRAMEWORK
 			using (var ecdh = new ECDiffieHellmanCng(privateDhmKey) { HashAlgorithm = CngAlgorithm.Sha384, SecretAppend = contextAppend, SecretPrepend = contextPrepend })
 				return ecdh.DeriveKeyMaterial(publicDhmKey);
-#elif NETCOREAPP2_1
+#elif NETCOREAPP
 
 			const int P384_POINT_BYTELENGTH = 48;
 			var privateDhmKeyBytes = new ArraySegment<byte>(privateDhmKey.GetPrivateBlob(),
@@ -91,6 +91,10 @@ namespace SecurityDriven.Inferno.Extensions
 					secretAppend: contextAppend
 					);
 			}
+#elif NETSTANDARD2_0
+			throw new PlatformNotSupportedException($"ECDiffieHellman is not supported on .NET Standard 2.0. Please reference \"{typeof(CngKeyExtensions).Assembly.GetName().Name}\" from .NET Framework or .NET Core for ECDiffieHellman support.");
+#else
+#error Unknown target
 #endif
 		}// GetSharedDhmSecret()
 

--- a/Hash/HashFactories.cs
+++ b/Hash/HashFactories.cs
@@ -7,31 +7,31 @@ namespace SecurityDriven.Inferno.Hash
 	{
 		static readonly Func<SHA1> ManagedSHA1 = () => new SHA1Managed();
 		static readonly Func<SHA1> FipsSHA1 =
-#if NET462
+#if NETFRAMEWORK
 			() => new SHA1Cng();
-#elif NETCOREAPP2_1
+#else
 			() => System.Security.Cryptography.SHA1.Create();
 #endif
 		static readonly Func<SHA256> ManagedSHA256 = () => new SHA256Managed();
 		static readonly Func<SHA256> FipsSHA256 =
-#if NET462
+#if NETFRAMEWORK
 			() => new SHA256Cng();
-#elif NETCOREAPP2_1
+#else
 			() => System.Security.Cryptography.SHA256.Create();
 #endif
 		static readonly Func<SHA384> ManagedSHA384 = () => new SHA384Managed();
 		static readonly Func<SHA384> FipsSHA384 =
-#if NET462
+#if NETFRAMEWORK
 			() => new SHA384Cng();
-#elif NETCOREAPP2_1
+#else
 			() => System.Security.Cryptography.SHA384.Create();
 #endif
 
 		static readonly Func<SHA512> ManagedSHA512 = () => new SHA512Managed();
 		static readonly Func<SHA512> FipsSHA512 =
-#if NET462
+#if NETFRAMEWORK
 			() => new SHA512Cng();
-#elif NETCOREAPP2_1
+#else
 			() => System.Security.Cryptography.SHA512.Create();
 #endif
 

--- a/Mac/HMAC2.cs
+++ b/Mac/HMAC2.cs
@@ -30,9 +30,9 @@ namespace SecurityDriven.Inferno.Mac
 		{
 			hashAlgorithm = hashFactory();
 			base.HashSizeValue = hashAlgorithm.HashSize;
-#if NET462
+#if NETFRAMEWORK
 			if (hashAlgorithm is SHA384Cng || hashAlgorithm is SHA512Cng || hashAlgorithm is SHA384 || hashAlgorithm is SHA512)
-#elif NETCOREAPP2_1
+#else
 			if (hashAlgorithm is SHA384 || hashAlgorithm is SHA512)
 #endif
 			{

--- a/SecurityDriven.Inferno.csproj
+++ b/SecurityDriven.Inferno.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netcoreapp2.1;net462</TargetFrameworks>
+		<TargetFrameworks>netcoreapp2.1;net462;netstandard2.0</TargetFrameworks>
 		<RootNamespace>SecurityDriven.Inferno</RootNamespace>
 		<Version>1.5.3.0</Version>
 		<Company>http://SecurityDriven.NET/inferno</Company>
@@ -12,31 +12,11 @@
 		<PackageProjectUrl>http://securitydriven.net/inferno/</PackageProjectUrl>
 		<PackageTags>crypto cryptography encryption security</PackageTags>
 		<AssemblyName>SecurityDriven.Inferno</AssemblyName>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 		<LangVersion>latest</LangVersion>
 	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-		<LangVersion>latest</LangVersion>
-		<AllowUnsafeBlocks>false</AllowUnsafeBlocks>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp2.1|AnyCPU'">
-		<DebugType>pdbonly</DebugType>
-		<DebugSymbols>true</DebugSymbols>
-	</PropertyGroup>
-
-	<ItemGroup>
-		<Compile Remove="Cipher\AesCtrCryptoTransform2.cs" />
-		<Compile Remove="Cipher\AesPool.cs" />
-		<Compile Remove="Mac\HMAC2_old.cs" />
-		<Compile Remove="Mac\HMAC3.cs" />
-	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-		<PackageReference Include="System.Security.Cryptography.Cng" Version="4.5.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
+		<PackageReference Include="System.Security.Cryptography.Cng" Version="4.5.0" Condition="'$(TargetFramework)' != 'net462'" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
The only unavailable feature is SecurityDriven.Inferno.Extensions.CngKeyExtensions.GetSharedDhmSecret because it uses Elliptic-curve Diffie–Hellman which is not available on .NET Standard 2.0.
