### PR TITLE
feat: Added net5/net6 targets. Added SupportedOSPlatform attrubutes for windows-specific code.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# SecurityDriven.Inferno Agent Context
+
+This file gives Codex and other agents enough repository context to work safely and to support later portfolio analysis.
+
+<!-- BEGIN GENERATED PORTFOLIO CONTEXT -->
+
+## Generated Repository Context
+
+This section was generated from the GitHub repository inventory and local checkout to support future Codex work and portfolio analysis.
+
+### Repository Metadata
+- Remote: https://github.com/HavenDV/SecurityDriven.Inferno
+- Visibility: public
+- Type: fork; active
+- Primary language: C#
+- Topics: None detected
+- Last pushed: 2022-03-12T08:38:14Z
+- Local path: /Users/havendv/GitHub/HavenDV/SecurityDriven.Inferno
+- Local note: standard checkout
+- Classification: Fork/reference workspace
+
+### Working Summary
+.NET crypto done right.
+
+### Detected Structure
+- Top-level items: `Cipher/`, `Extensions/`, `Hash/`, `Kdf/`, `Mac/`, `Otp/`, `Properties/`, `.gitattributes`, `.gitignore`, `CryptoRandom.cs`, `EtM_CBC.cs`, `EtM_CTR.cs`, `EtM_Transforms.cs`, `LICENSE.md`, `README.md`
+- Sampled file count: 30
+- Common extensions: .cs (24), .md (2), [no extension] (2), .sln (1), .csproj (1)
+
+### Manifests And Commands
+- SecurityDriven.Inferno.sln
+
+Suggested commands:
+- dotnet build SecurityDriven.Inferno.sln
+
+Testing signal:
+- No automated test entry point was detected by the generator.
+
+### Portfolio Signals
+- Skills: .NET, NuGet packaging, C#
+- Portfolio angle: Use as evidence of ecosystem study, patch/reference work, or upstream contribution only after checking actual commits.
+
+### Agent Notes
+- Prefer README and manifest instructions over generated assumptions when they disagree.
+- Keep generated context current when build tooling, test commands, or project scope changes.
+- Review private or client-specific details before copying portfolio claims into public material.
+
+<!-- END GENERATED PORTFOLIO CONTEXT -->

--- a/Cipher/AesFactories.cs
+++ b/Cipher/AesFactories.cs
@@ -7,8 +7,10 @@ namespace SecurityDriven.Inferno.Cipher
 	{
 		internal static readonly Func<Aes> ManagedAes = () => new AesManaged();
 		internal static readonly Func<Aes> FipsAes = Environment.OSVersion.Platform == PlatformID.Win32NT ?
-			(Func<Aes>)(() => new AesCng()) :		// Windows
-			() => new AesCryptoServiceProvider();	// non-Windows
+#pragma warning disable CA1416 // Validate platform compatibility
+            (Func<Aes>)(() => new AesCng()) :       // Windows
+#pragma warning restore CA1416 // Validate platform compatibility
+            () => new AesCryptoServiceProvider();	// non-Windows
 
 		public static readonly Func<Aes> Aes = Utils.AllowOnlyFipsAlgorithms ? FipsAes : ManagedAes;
 	}//class AesFactories

--- a/Extensions/CngKeyExtensions.cs
+++ b/Extensions/CngKeyExtensions.cs
@@ -6,29 +6,72 @@ namespace SecurityDriven.Inferno.Extensions
 {
 	public static class CngKeyExtensions
 	{
+#if NET5_0_OR_GREATER
+		[System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#elif NETSTANDARD2_0_OR_GREATER || NET461_OR_GREATER || NETCOREAPP3_1
+#else
+#error Target Framework is not supported
+#endif
 		static readonly CngKeyCreationParameters cngKeyCreationParameters = new CngKeyCreationParameters { ExportPolicy = CngExportPolicies.AllowPlaintextExport };
+
+#if NET5_0_OR_GREATER
+		[System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#elif NETSTANDARD2_0_OR_GREATER || NET461_OR_GREATER || NETCOREAPP3_1
+#else
+#error Target Framework is not supported
+#endif
 		static readonly CngProperty exportPolicy_AllowPlaintextExport = new CngProperty("Export Policy", BitConverter.GetBytes((int)CngExportPolicies.AllowPlaintextExport), CngPropertyOptions.None);
 
+#if NET5_0_OR_GREATER
+		[System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#elif NETSTANDARD2_0_OR_GREATER || NET461_OR_GREATER || NETCOREAPP3_1
+#else
+#error Target Framework is not supported
+#endif
 		public static CngKey CreateNewDhmKey(string name = null)
 		{
 			return CngKey.Create(CngAlgorithm.ECDiffieHellmanP384, name, cngKeyCreationParameters);
 		}
 
+#if NET5_0_OR_GREATER
+		[System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#elif NETSTANDARD2_0_OR_GREATER || NET461_OR_GREATER || NETCOREAPP3_1
+#else
+#error Target Framework is not supported
+#endif
 		public static CngKey CreateNewDsaKey(string name = null)
 		{
 			return CngKey.Create(CngAlgorithm.ECDsaP384, name, cngKeyCreationParameters);
 		}
 
+#if NET5_0_OR_GREATER
+		[System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#elif NETSTANDARD2_0_OR_GREATER || NET461_OR_GREATER || NETCOREAPP3_1
+#else
+#error Target Framework is not supported
+#endif
 		public static byte[] GetPrivateBlob(this CngKey key)
 		{
 			return key.Export(CngKeyBlobFormat.EccPrivateBlob);
 		}
 
+#if NET5_0_OR_GREATER
+		[System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#elif NETSTANDARD2_0_OR_GREATER || NET461_OR_GREATER || NETCOREAPP3_1
+#else
+#error Target Framework is not supported
+#endif
 		public static byte[] GetPublicBlob(this CngKey key)
 		{
 			return key.Export(CngKeyBlobFormat.EccPublicBlob);
 		}
 
+#if NET5_0_OR_GREATER
+		[System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#elif NETSTANDARD2_0_OR_GREATER || NET461_OR_GREATER || NETCOREAPP3_1
+#else
+#error Target Framework is not supported
+#endif
 		public static CngKey ToPrivateKeyFromBlob(this byte[] privateBlob)
 		{
 			var key = CngKey.Import(privateBlob, CngKeyBlobFormat.EccPrivateBlob);
@@ -36,6 +79,12 @@ namespace SecurityDriven.Inferno.Extensions
 			return key;
 		}
 
+#if NET5_0_OR_GREATER
+		[System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#elif NETSTANDARD2_0_OR_GREATER || NET461_OR_GREATER || NETCOREAPP3_1
+#else
+#error Target Framework is not supported
+#endif
 		public static CngKey ToPublicKeyFromBlob(this byte[] publicBlob)
 		{
 			return CngKey.Import(publicBlob, CngKeyBlobFormat.EccPublicBlob);
@@ -44,9 +93,15 @@ namespace SecurityDriven.Inferno.Extensions
 		/// <summary>
 		/// Both parties are static and authenticated.
 		/// </summary>
+#if NET5_0_OR_GREATER
+		[System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#elif NETSTANDARD2_0_OR_GREATER || NET461_OR_GREATER || NETCOREAPP3_1
+#else
+#error Target Framework is not supported
+#endif
 		public static byte[] GetSharedDhmSecret(this CngKey privateDhmKey, CngKey publicDhmKey, byte[] contextAppend = null, byte[] contextPrepend = null)
 		{
-#if (NET462 || NETCOREAPP3_1)
+#if (NET462 || NETCOREAPP3_1 || NET5_0 || NET6_0)
 			using (var ecdh = new ECDiffieHellmanCng(privateDhmKey) { HashAlgorithm = CngAlgorithm.Sha384, SecretAppend = contextAppend, SecretPrepend = contextPrepend })
 				return ecdh.DeriveKeyMaterial(publicDhmKey);
 #elif NETSTANDARD2_0
@@ -60,6 +115,12 @@ namespace SecurityDriven.Inferno.Extensions
 		/// Sender is anonymous and keyless.
 		/// Receiver is static and authenticated.
 		/// </summary>
+#if NET5_0_OR_GREATER
+		[System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#elif NETSTANDARD2_0_OR_GREATER || NET461_OR_GREATER || NETCOREAPP3_1
+#else
+#error Target Framework is not supported
+#endif
 		public static SharedEphemeralBundle GetSharedEphemeralDhmSecret(this CngKey receiverDhmPublicKey, byte[] contextAppend = null, byte[] contextPrepend = null)
 		{
 			using (var sender = CreateNewDhmKey())

--- a/SecurityDriven.Inferno.csproj
+++ b/SecurityDriven.Inferno.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netcoreapp3.1;net462;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net5;net6;netcoreapp3.1;net462;netstandard2.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<RootNamespace>SecurityDriven.Inferno</RootNamespace>
@@ -26,6 +26,7 @@
 		<AssemblyOriginatorKeyFile>Inferno.snk</AssemblyOriginatorKeyFile>
 		<DelaySign>false</DelaySign>
 		<Nullable>warnings</Nullable>
+    <!--<NoWarn>$(NoWarn);CS8602;CS8604;CS8629;NU5048;CS8601;CS8625;SYSLIB0021</NoWarn>-->
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)'=='Release'">


### PR DESCRIPTION
I researched my library for cross-platform compatibility. And since our encryption add-on uses your library, I also checked you out and made a PR based on that.
There are also quite a few warnings here, I can fix them after your answer. They are all listed in a commented out NoWarn block.

Initial issue: https://github.com/HavenDV/H.Pipes/issues/15