### PR TITLE
Add support for .NET 8 (which is the latest LTS)

### DIFF
--- a/Extensions/CngKeyExtensions.cs
+++ b/Extensions/CngKeyExtensions.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Security.Cryptography;
-using System.Linq;
 
 namespace SecurityDriven.Inferno.Extensions
 {
+#if NET5_0_OR_GREATER
+	[System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
 	public static class CngKeyExtensions
 	{
 		static readonly CngKeyCreationParameters cngKeyCreationParameters = new CngKeyCreationParameters { ExportPolicy = CngExportPolicies.AllowPlaintextExport };
@@ -46,13 +48,11 @@ namespace SecurityDriven.Inferno.Extensions
 		/// </summary>
 		public static byte[] GetSharedDhmSecret(this CngKey privateDhmKey, CngKey publicDhmKey, byte[] contextAppend = null, byte[] contextPrepend = null)
 		{
-#if (NET462 || NETCOREAPP3_1)
-			using (var ecdh = new ECDiffieHellmanCng(privateDhmKey) { HashAlgorithm = CngAlgorithm.Sha384, SecretAppend = contextAppend, SecretPrepend = contextPrepend })
-				return ecdh.DeriveKeyMaterial(publicDhmKey);
-#elif NETSTANDARD2_0
+#if NETSTANDARD2_0
 			throw new PlatformNotSupportedException($"ECDiffieHellman is not supported on .NET Standard 2.0. Please reference \"{typeof(CngKeyExtensions).Assembly.GetName().Name}\" from .NET Framework or .NET Core for ECDiffieHellman support.");
 #else
-#error Unknown target
+			using (var ecdh = new ECDiffieHellmanCng(privateDhmKey) { HashAlgorithm = CngAlgorithm.Sha384, SecretAppend = contextAppend, SecretPrepend = contextPrepend })
+				return ecdh.DeriveKeyMaterial(publicDhmKey);
 #endif
 		}// GetSharedDhmSecret()
 

--- a/SecurityDriven.Inferno.csproj
+++ b/SecurityDriven.Inferno.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netcoreapp3.1;net462;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;netcoreapp3.1;net462;netstandard2.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<RootNamespace>SecurityDriven.Inferno</RootNamespace>
@@ -41,11 +41,14 @@
 		<Compile Remove="Mac\HMAC3.cs" />
 	</ItemGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition="$(TargetFramework) == 'netstandard2.0' OR $(TargetFramework) == 'net462'">
 		<PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
 		<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-		<PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" Condition="'$(TargetFramework)' != 'net462'" />
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition="$(TargetFramework) == 'netstandard2.0' OR $(TargetFramework) == 'netcoreapp3.1'">
+		<PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
 	</ItemGroup>
 
 </Project>

--- a/SecurityDriven.Inferno.csproj
+++ b/SecurityDriven.Inferno.csproj
@@ -49,6 +49,7 @@
 
 	<ItemGroup Condition="$(TargetFramework) == 'netstandard2.0' OR $(TargetFramework) == 'netcoreapp3.1'">
 		<PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
+		<PackageReference Include="System.Formats.Asn1" Version="9.0.0" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
This allows to use Inferno completely dependency free since `System.Numerics.Vectors`, `System.Runtime.CompilerServices.Unsafe`, `System.ValueTuple` and `System.Security.Cryptography.Cng` are only required for specific target frameworks.

Also update `System.Formats.Asn1` to fix this NU1903 warning:
> Package 'System.Formats.Asn1' 5.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-447r-wph3-92pm

This pull request supersedes #40